### PR TITLE
Bm child nodes

### DIFF
--- a/converter/flare/converter.js
+++ b/converter/flare/converter.js
@@ -5,7 +5,7 @@ import nodeId from '../helpers/nodeId'
 const convert = async(animation) => {
 
 	const board = await artboard(animation)
-	const assetsArray = assets(animation.assets)
+	const assetsArray = assets(animation.assets || [])
 
 	return {
 		artboards: {

--- a/converter/flare/helpers/propertyConverter.js
+++ b/converter/flare/helpers/propertyConverter.js
@@ -41,14 +41,14 @@ const gradientTypes = [
 ]
 
 export const createColorStop = (colors, stops, extraValues = []) => {
-	const hasAlphaValue = colors.length === stops * 5;
+	const hasAlphaValue = colors.length === stops * 6;
 
 	let count = 0;
 	let value = [...extraValues];
 	while (count < stops) {
-		const index = hasAlphaValue ? count * 5 : count * 4;
+		const index = count * 4;
 		const currentStop = [colors[index + 1], colors[index + 2], colors[index + 3]];
-		currentStop.push(hasAlphaValue ? colors[index + 4] : 1);
+		currentStop.push(hasAlphaValue ? colors[stops * 4 + count * 2 + 1] : 1);
 		currentStop.push(colors[index]);
 		value = value.concat(currentStop);
 		count += 1;

--- a/converter/flare/helpers/visibilityModes.js
+++ b/converter/flare/helpers/visibilityModes.js
@@ -1,0 +1,5 @@
+export const visibilityModes = {
+	HIDDEN_LOCAL: 'hidden local',
+	HIDDEN_FULL: 'hidden full',
+	VISIBLE: 'visible',
+}

--- a/converter/flare/models/FlareArtboard.js
+++ b/converter/flare/models/FlareArtboard.js
@@ -28,7 +28,7 @@ export default class FlareArtboard extends FlarePrecompLayer {
 			color: [0,0,0,0],
 			clipContents: true,
 			animations: this._Animations.convert(),
-			children
+			children: [children]
 		}
 	}
 }

--- a/converter/flare/models/FlareContent.js
+++ b/converter/flare/models/FlareContent.js
@@ -5,9 +5,9 @@ import ShapeCollection from "./shapes/ShapeCollection";
 
 export default class FlareContent extends FlareLayer {
 
-	constructor(lottieLayer, animations, offsetTime) {
+	constructor(lottieLayer, animations, offsetTime, isHidden) {
 
-		super(lottieLayer, animations, offsetTime)
+		super(lottieLayer, animations, offsetTime, isHidden)
 
 	}
 
@@ -101,10 +101,6 @@ export default class FlareContent extends FlareLayer {
 		const offsetTime = this.offsetTime
 
 		let content = this.convertContent(lottieLayer, animations, offsetTime)
-
-		if (lottieLayer.isTrackMask) {
-			content[0].hidden = true
-		}
 
 		return this.createContentWrapper(content)
 

--- a/converter/flare/models/FlareContent.js
+++ b/converter/flare/models/FlareContent.js
@@ -35,7 +35,8 @@ export default class FlareContent extends FlareLayer {
 			})
 
 			const convertedMask = shapeCollection.convert(animations, offsetTime)
-			content.push(convertedMask)
+
+			content = [content, convertedMask]
 
 			const maskNode = new FlareNode(name + '_Clip', content)
 			maskNode.clips = [convertedMask.id]
@@ -43,7 +44,7 @@ export default class FlareContent extends FlareLayer {
 			content = maskNode.convert()
 		}
 
-		if (lottieLayer.transform && lottieLayer.transform.opacity) {
+		if (this._Transforms && this._Transforms.opacity) {
 			
 			const children = content
 

--- a/converter/flare/models/FlareContent.js
+++ b/converter/flare/models/FlareContent.js
@@ -5,11 +5,9 @@ import ShapeCollection from "./shapes/ShapeCollection";
 
 export default class FlareContent extends FlareLayer {
 
-	constructor(lottieLayer, animations, offsetTime, converter) {
+	constructor(lottieLayer, animations, offsetTime) {
 
 		super(lottieLayer, animations, offsetTime)
-
-		this._Converter = converter
 
 	}
 
@@ -98,13 +96,15 @@ export default class FlareContent extends FlareLayer {
 
 	createContent() {
 
-		const converter = this.convertContent || this._Converter
-
 		const lottieLayer = this.lottieLayer
 		const animations = this._Animations
 		const offsetTime = this.offsetTime
 
 		let content = this.convertContent(lottieLayer, animations, offsetTime)
+
+		if (lottieLayer.isTrackMask) {
+			content[0].hidden = true
+		}
 
 		return this.createContentWrapper(content)
 

--- a/converter/flare/models/FlareContent.js
+++ b/converter/flare/models/FlareContent.js
@@ -40,7 +40,7 @@ export default class FlareContent extends FlareLayer {
 			const maskNode = new FlareNode(name + '_Clip', content)
 			maskNode.clips = [convertedMask.id]
 
-			content = [maskNode.convert()]
+			content = maskNode.convert()
 		}
 
 		if (lottieLayer.transform && lottieLayer.transform.opacity) {
@@ -52,7 +52,7 @@ export default class FlareContent extends FlareLayer {
 
 			opacityNode.opacity = convertProperty(lottieLayer.transform.opacity, 'opacity', animations, opacityNode.id, 0.01, offsetTime)
 
-			content = [opacityNode.convert()]
+			content = opacityNode.convert()
 		}
 
 		if (lottieLayer.inPoint + this.offsetTime > animations.inPoint || lottieLayer.outPoint + this.offsetTime < animations.outPoint) {
@@ -87,9 +87,10 @@ export default class FlareContent extends FlareLayer {
 				keyframes,
 			}, 'opacity', animations, inOutNode.id, 0.01, offsetTime);
 
-			content = [inOutNode.convert()]
+			content = inOutNode.convert()
 
 		}
+
 
 		return content
 	}

--- a/converter/flare/models/FlareContent.js
+++ b/converter/flare/models/FlareContent.js
@@ -45,7 +45,7 @@ export default class FlareContent extends FlareLayer {
 		}
 
 		if (this._Transforms && this._Transforms.opacity) {
-			
+
 			const children = content
 
 			const opacityNode = new FlareNode(name + '_Opacity', children)

--- a/converter/flare/models/FlareLayer.js
+++ b/converter/flare/models/FlareLayer.js
@@ -1,17 +1,19 @@
 import FlareTransform from './properties/FlareTransform'
 import FlareNode from './nodes/FlareNode'
 import {addChildrenToLastLeaves} from '../helpers/lastLeavesHelper.js';
+import {visibilityModes} from '../helpers/visibilityModes.js';
 
 export default class FlareLayer
 {
 
-	constructor(lottieLayer, animations, offsetTime)
+	constructor(lottieLayer, animations, offsetTime, isHidden)
 	{
 		this._LottieLayer = lottieLayer
 		this._Animations = animations
 		this._OffsetTime = offsetTime
 		this._Transforms = new FlareTransform(lottieLayer.transform, lottieLayer.name)
 		this._Children = []
+		this._Visibility = isHidden ? visibilityModes.HIDDEN_FULL : lottieLayer.isTrackMask ? visibilityModes.HIDDEN_LOCAL : visibilityModes.VISIBLE
 		this._ContentId = null
 		this._PreviousChild = null
 	}
@@ -77,6 +79,10 @@ export default class FlareLayer
 
 	get contentId() {
 		return this._ContentId
+	}
+
+	get visibility() {
+		return this._Visibility
 	}
 
 	set previous(child) {

--- a/converter/flare/models/FlareLayer.js
+++ b/converter/flare/models/FlareLayer.js
@@ -57,9 +57,6 @@ export default class FlareLayer
 
 		}
 		
-
-
-
 		const transform = this._Transforms.convert(this._Animations, this.offsetTime)
 
 		if (transform) {

--- a/converter/flare/models/FlareLayer.js
+++ b/converter/flare/models/FlareLayer.js
@@ -1,6 +1,6 @@
 import FlareTransform from './properties/FlareTransform'
 import FlareNode from './nodes/FlareNode'
-import {addChildrenToLastLeaves} from '../helpers/lastLeavesHelper.js';
+import {addChildToLastLeaves} from '../helpers/lastLeavesHelper.js';
 import {visibilityModes} from '../helpers/visibilityModes.js';
 
 export default class FlareLayer
@@ -26,23 +26,9 @@ export default class FlareLayer
 
 	convert() {
 
-
-		let children = this._Children.map(child => {return child.convert()})
-
-		const content = this.createContent()
-
-		children = content.concat(children)
-
-		const transform = this._Transforms.convert(this._Animations, this.offsetTime)
-
-		if (transform) {
-			addChildrenToLastLeaves(transform, children)
-			children = transform
-		}
-
-
+		let content = this.createContent()
 		///
-		const maskedChild = children.length ? children[0] : children;
+		const maskedChild = content;
 		this._ContentId = maskedChild.id;
 
 
@@ -61,8 +47,30 @@ export default class FlareLayer
 		}
 
 		maskedChild.maskType = maskType;
+		////
 
-		return children
+		if (this._Children.length) {
+			let children = this._Children.map(child => {return child.convert()})
+			children = [content].concat(children)
+
+			content = new FlareNode(name + '_Parenter', children).convert()
+
+		}
+		
+
+
+
+		const transform = this._Transforms.convert(this._Animations, this.offsetTime)
+
+		if (transform) {
+			addChildToLastLeaves(transform, content)
+			content = transform
+		}
+
+
+		
+
+		return content
 	}
 
 	addChild(child) {

--- a/converter/flare/models/FlareLayerImage.js
+++ b/converter/flare/models/FlareLayerImage.js
@@ -1,5 +1,6 @@
 import FlareContent from './FlareContent';
 import nodeId from '../../helpers/nodeId';
+import {visibilityModes} from '../helpers/visibilityModes.js';
 
 export default class FlareLayerSolid extends FlareContent {
 
@@ -18,6 +19,7 @@ export default class FlareLayerSolid extends FlareContent {
 				id: nodeId(),
 				name: "Image",
 				asset: assetData.id,
+				hidden: this.visibility !== visibilityModes.VISIBLE,
 				
 				// Flare can use this as a hint to find an
 				// existing asset that's already loaded

--- a/converter/flare/models/FlareLayerImage.js
+++ b/converter/flare/models/FlareLayerImage.js
@@ -13,186 +13,183 @@ export default class FlareLayerSolid extends FlareContent {
 
 		const verticesIds = [nodeId(), nodeId(), nodeId(), nodeId()]
 
-		return [
-			{
-				type: "image",
-				id: nodeId(),
-				name: "Image",
-				asset: assetData.id,
-				hidden: this.visibility !== visibilityModes.VISIBLE,
-				
-				// Flare can use this as a hint to find an
-				// existing asset that's already loaded
-				// (in case the images are imported separately)
-				assetPath: assetData.u + assetData.p,
+		return {
+			type: "image",
+			id: nodeId(),
+			name: "Image",
+			asset: assetData.id,
+			hidden: this.visibility !== visibilityModes.VISIBLE,
+			
+			// Flare can use this as a hint to find an
+			// existing asset that's already loaded
+			// (in case the images are imported separately)
+			assetPath: assetData.u + assetData.p,
 
-				blendMode: "srcOver",
-				drawOrder: layer.drawOrder,
-				translation: [assetWidth / 2, assetHeight / 2],
-				"tris": [
-					3,
-					0,
-					1,
-					1,
-					2,
-					3
-				],
-				children: [
-					{
-						"type": "meshPoint",
-						"id": verticesIds[0],
-						"name": "Node",
-						"translation": [
-							-assetWidth / 2,
-							-assetHeight / 2
-						],
-						"uv": [
-							0,
-							0
-						],
-						"contour": verticesIds[1],
-						"isForced": false
-					},
-					{
-						"type": "meshPoint",
-						"id": verticesIds[1],
-						"name": "Node",
-						"translation": [
-							assetWidth / 2,
-							-assetHeight / 2
-						],
-						"uv": [
-							assetWidth,
-							0
-						],
-						"contour": verticesIds[2],
-						"isForced": false
-					},
-					{
-						"type": "meshPoint",
-						"id": verticesIds[2],
-						"name": "Node",
-						"translation": [
-							assetWidth / 2,
-							assetHeight / 2
-						],
-						"uv": [
-							assetWidth,
-							assetHeight
-						],
-						"contour": verticesIds[3],
-						"isForced": false
-					},
-					{
-						"type": "meshPoint",
-						"id": verticesIds[3],
-						"name": "Node",
-						"translation": [
-							-assetWidth / 2,
-							assetHeight / 2
-						],
-						"uv": [
-							0,
-							assetHeight
-						],
-						"contour": verticesIds[0],
-						"isForced": false
-					},
-					{
-						"type": "meshDeformPoint",
-						"id": nodeId(),
-						"name": "Node",
-						"translation": [
-							-assetWidth / 2,
-							-assetHeight / 2
-						],
-						"uv": [
-							0,
-							0
-						],
-						"weights": [
-							1,
-							0,
-							0,
-							0,
-							1,
-							0,
-							0,
-							0
-						]
-					},
-					{
-						"type": "meshDeformPoint",
-						"id": nodeId(),
-						"name": "Node",
-						"translation": [
-							assetWidth / 2,
-							-assetHeight / 2
-						],
-						"uv": [
-							assetWidth,
-							0
-						],
-						"weights": [
-							1,
-							0,
-							0,
-							0,
-							1,
-							0,
-							0,
-							0
-						]
-					},
-					{
-						"type": "meshDeformPoint",
-						"id": nodeId(),
-						"name": "Node",
-						"translation": [
-							assetWidth / 2,
-							assetHeight / 2
-						],
-						"uv": [
-							assetWidth,
-							assetHeight
-						],
-						"weights": [
-							1,
-							0,
-							0,
-							0,
-							1,
-							0,
-							0,
-							0
-						]
-					},
-					{
-						"type": "meshDeformPoint",
-						"id": nodeId(),
-						"name": "Node",
-						"translation": [
-							-assetWidth / 2,
-							assetHeight / 2
-						],
-						"uv": [
-							0,
-							assetHeight
-						],
-						"weights": [
-							1,
-							0,
-							0,
-							0,
-							1,
-							0,
-							0,
-							0
-						]
-					}
-				]
-			}
-		]
-
+			blendMode: "srcOver",
+			drawOrder: layer.drawOrder,
+			translation: [assetWidth / 2, assetHeight / 2],
+			"tris": [
+				3,
+				0,
+				1,
+				1,
+				2,
+				3
+			],
+			children: [
+				{
+					"type": "meshPoint",
+					"id": verticesIds[0],
+					"name": "Node",
+					"translation": [
+						-assetWidth / 2,
+						-assetHeight / 2
+					],
+					"uv": [
+						0,
+						0
+					],
+					"contour": verticesIds[1],
+					"isForced": false
+				},
+				{
+					"type": "meshPoint",
+					"id": verticesIds[1],
+					"name": "Node",
+					"translation": [
+						assetWidth / 2,
+						-assetHeight / 2
+					],
+					"uv": [
+						assetWidth,
+						0
+					],
+					"contour": verticesIds[2],
+					"isForced": false
+				},
+				{
+					"type": "meshPoint",
+					"id": verticesIds[2],
+					"name": "Node",
+					"translation": [
+						assetWidth / 2,
+						assetHeight / 2
+					],
+					"uv": [
+						assetWidth,
+						assetHeight
+					],
+					"contour": verticesIds[3],
+					"isForced": false
+				},
+				{
+					"type": "meshPoint",
+					"id": verticesIds[3],
+					"name": "Node",
+					"translation": [
+						-assetWidth / 2,
+						assetHeight / 2
+					],
+					"uv": [
+						0,
+						assetHeight
+					],
+					"contour": verticesIds[0],
+					"isForced": false
+				},
+				{
+					"type": "meshDeformPoint",
+					"id": nodeId(),
+					"name": "Node",
+					"translation": [
+						-assetWidth / 2,
+						-assetHeight / 2
+					],
+					"uv": [
+						0,
+						0
+					],
+					"weights": [
+						1,
+						0,
+						0,
+						0,
+						1,
+						0,
+						0,
+						0
+					]
+				},
+				{
+					"type": "meshDeformPoint",
+					"id": nodeId(),
+					"name": "Node",
+					"translation": [
+						assetWidth / 2,
+						-assetHeight / 2
+					],
+					"uv": [
+						assetWidth,
+						0
+					],
+					"weights": [
+						1,
+						0,
+						0,
+						0,
+						1,
+						0,
+						0,
+						0
+					]
+				},
+				{
+					"type": "meshDeformPoint",
+					"id": nodeId(),
+					"name": "Node",
+					"translation": [
+						assetWidth / 2,
+						assetHeight / 2
+					],
+					"uv": [
+						assetWidth,
+						assetHeight
+					],
+					"weights": [
+						1,
+						0,
+						0,
+						0,
+						1,
+						0,
+						0,
+						0
+					]
+				},
+				{
+					"type": "meshDeformPoint",
+					"id": nodeId(),
+					"name": "Node",
+					"translation": [
+						-assetWidth / 2,
+						assetHeight / 2
+					],
+					"uv": [
+						0,
+						assetHeight
+					],
+					"weights": [
+						1,
+						0,
+						0,
+						0,
+						1,
+						0,
+						0,
+						0
+					]
+				}
+			]
+		}
 	}
 }

--- a/converter/flare/models/FlareLayerShape.js
+++ b/converter/flare/models/FlareLayerShape.js
@@ -1,6 +1,7 @@
 import FlareContent from './FlareContent';
 import shapeTypes from '../../lottie/shapes/shapeTypes.js';
 import ShapeCollection from './shapes/ShapeCollection';
+import {visibilityModes} from '../helpers/visibilityModes.js';
 
 const pathTypes = [
 	shapeTypes.PATH,
@@ -62,11 +63,11 @@ export default class FlareLayerShape extends FlareContent {
 		return shapes
 	}
 
-	buildShapes(items, animations, offsetTime) {
+	buildShapes(items, animations, offsetTime, isHidden) {
 		const tranforms = [];
 		const modifiers = [];
 		const shapes = this.iterateGroup(items, [], tranforms, modifiers)
-		.map(shapeCollection => shapeCollection.convert(animations, offsetTime));
+		.map(shapeCollection => shapeCollection.convert(animations, offsetTime, isHidden));
 
 		return shapes;
 	}
@@ -77,7 +78,9 @@ export default class FlareLayerShape extends FlareContent {
 		const animations = this._Animations
 		const offsetTime = this.offsetTime
 
-		return this.buildShapes(layer.items, animations, offsetTime);
+		const isHidden = this.visibility !== visibilityModes.VISIBLE 
+
+		return this.buildShapes(layer.items, animations, offsetTime, isHidden);
 
 	}
 }

--- a/converter/flare/models/FlareLayerShape.js
+++ b/converter/flare/models/FlareLayerShape.js
@@ -2,6 +2,7 @@ import FlareContent from './FlareContent';
 import shapeTypes from '../../lottie/shapes/shapeTypes.js';
 import ShapeCollection from './shapes/ShapeCollection';
 import {visibilityModes} from '../helpers/visibilityModes.js';
+import FlareNode from './nodes/FlareNode';
 
 const pathTypes = [
 	shapeTypes.PATH,
@@ -69,7 +70,7 @@ export default class FlareLayerShape extends FlareContent {
 		const shapes = this.iterateGroup(items, [], tranforms, modifiers)
 		.map(shapeCollection => shapeCollection.convert(animations, offsetTime, isHidden));
 
-		return shapes;
+		return new FlareNode('Shapes_Container', shapes).convert();
 	}
 
 	convertContent() {

--- a/converter/flare/models/FlareLayerSolid.js
+++ b/converter/flare/models/FlareLayerSolid.js
@@ -30,20 +30,18 @@ export default class FlareLayerSolid extends FlareContent {
 			}
 		})
 
-		return [
-			{
-				type: "shape",
-				id: nodeId(),
-				name: "Shape",
-				blendMode: "srcOver",
-				drawOrder: layer.drawOrder,
-				children: [
-					shapeFill.convert('', null, null, null),
-					shapeRectangle.convert(null, null),
-				],
-				hidden: this.visibility !== visibilityModes.VISIBLE,
-			}
-		]
+		return {
+			type: "shape",
+			id: nodeId(),
+			name: "Shape",
+			blendMode: "srcOver",
+			drawOrder: layer.drawOrder,
+			children: [
+				shapeFill.convert('', null, null, null),
+				shapeRectangle.convert(null, null),
+			],
+			hidden: this.visibility !== visibilityModes.VISIBLE,
+		}
 
 	}
 }

--- a/converter/flare/models/FlareLayerSolid.js
+++ b/converter/flare/models/FlareLayerSolid.js
@@ -2,6 +2,7 @@ import FlareContent from './FlareContent';
 import FlareShapeFill from './shapes/FlareShapeFill';
 import FlareShapeRectangle from './shapes/FlareShapeRectangle';
 import nodeId from '../../helpers/nodeId';
+import {visibilityModes} from '../helpers/visibilityModes.js';
 
 export default class FlareLayerSolid extends FlareContent {
 
@@ -39,7 +40,8 @@ export default class FlareLayerSolid extends FlareContent {
 				children: [
 					shapeFill.convert('', null, null, null),
 					shapeRectangle.convert(null, null),
-				]
+				],
+				hidden: this.visibility !== visibilityModes.VISIBLE,
 			}
 		]
 

--- a/converter/flare/models/FlarePrecompLayer.js
+++ b/converter/flare/models/FlarePrecompLayer.js
@@ -55,7 +55,7 @@ export default class FlarePrecompLayer extends FlareContent {
 		return remaining
 	}
 
-	convertChild(child, index, children) {
+	convertChild(child) {
 		return child.convert()
 	}
 

--- a/converter/flare/models/FlarePrecompLayer.js
+++ b/converter/flare/models/FlarePrecompLayer.js
@@ -53,11 +53,21 @@ export default class FlarePrecompLayer extends FlareContent {
 		return remaining
 	}
 
+	convertChild(child, index, children) {
+		return child.convert()
+	}
+
+	linkLayer(child, index, children) {
+		child.previous = children[index - 1];
+		return child;
+	}
+
 	convertLayers(layers) {
 		return layers
 		.reverse()
 		.map(this.createLayer)
+		.map(this.linkLayer)
 		.reduce(this.nestChildLayers,[])
-		.map(child => child.convert())
+		.map(this.convertChild)
 	}
 }

--- a/converter/flare/models/FlarePrecompLayer.js
+++ b/converter/flare/models/FlarePrecompLayer.js
@@ -4,6 +4,7 @@ import FlareLayerSolid from './FlareLayerSolid';
 import FlareLayerImage from './FlareLayerImage';
 import FlareLayerShape from './FlareLayerShape';
 import {visibilityModes} from '../helpers/visibilityModes.js';
+import FlareNode from './nodes/FlareNode';
 
 export default class FlarePrecompLayer extends FlareContent {
 
@@ -64,12 +65,14 @@ export default class FlarePrecompLayer extends FlareContent {
 		return child;
 	}
 
-	convertLayers(layers) {
-		return layers
+	convertLayers(lottieLayers) {
+		const layers = lottieLayers
 		.reverse()
 		.map(this.createLayer)
 		.map(this.linkLayer)
 		.reduce(this.nestChildLayers,[])
 		.map(this.convertChild)
+
+		return new FlareNode('Precomp_Container', layers).convert()
 	}
 }

--- a/converter/flare/models/FlarePrecompLayer.js
+++ b/converter/flare/models/FlarePrecompLayer.js
@@ -3,11 +3,12 @@ import FlareLayerNull from './FlareLayerNull';
 import FlareLayerSolid from './FlareLayerSolid';
 import FlareLayerImage from './FlareLayerImage';
 import FlareLayerShape from './FlareLayerShape';
+import {visibilityModes} from '../helpers/visibilityModes.js';
 
 export default class FlarePrecompLayer extends FlareContent {
 
-	constructor(lottieLayer, animations, offsetTime) {
-		super(lottieLayer, animations, offsetTime)
+	constructor(lottieLayer, animations, offsetTime, isHidden) {
+		super(lottieLayer, animations, offsetTime, isHidden)
 
 		this.createLayer = this.createLayer.bind(this)
 	}
@@ -15,18 +16,19 @@ export default class FlarePrecompLayer extends FlareContent {
 	createLayer(layer) {
 
 		const offsetTime = this.lottieLayer.startPoint + this.offsetTime
+		const isHidden = this.visibility !== visibilityModes.VISIBLE
 
 		switch(layer.type) {
 			case 0:
-			return new FlarePrecompLayer(layer, this._Animations, offsetTime);
+			return new FlarePrecompLayer(layer, this._Animations, offsetTime, isHidden);
 			case 1:
-			return new FlareLayerSolid(layer, this._Animations, offsetTime);
+			return new FlareLayerSolid(layer, this._Animations, offsetTime, isHidden);
 			case 2:
-			return new FlareLayerImage(layer, this._Animations, offsetTime);
+			return new FlareLayerImage(layer, this._Animations, offsetTime, isHidden);
 			case 3:
-			return new FlareLayerNull(layer, this._Animations, offsetTime);
+			return new FlareLayerNull(layer, this._Animations, offsetTime, isHidden);
 			case 4:
-			return new FlareLayerShape(layer, this._Animations, offsetTime);
+			return new FlareLayerShape(layer, this._Animations, offsetTime, isHidden);
 			default:
 			return null
 		}

--- a/converter/flare/models/nodes/FlareNode.js
+++ b/converter/flare/models/nodes/FlareNode.js
@@ -5,6 +5,9 @@ export default class FlareNode {
 	constructor(name = 'NodeName', children = [], type = 'node', transform = {}, opacity = 1) {
 
 		this._Id = nodeId();
+		if (!Array.isArray(children) && children) {
+			children = [children]
+		}
 		this._Children = children;
 		this._Transform = transform;
 		this._Opacity = opacity;
@@ -18,7 +21,10 @@ export default class FlareNode {
 	}
 
 	addChild(child) {
-		this._Children.push(child)
+		if (!Array.isArray(child) && child) {
+			child = [child]
+		}
+		this.addChildren(child)
 	}
 
 	convert() {

--- a/converter/flare/models/properties/FlareTransform.js
+++ b/converter/flare/models/properties/FlareTransform.js
@@ -12,9 +12,9 @@ export default class FlareTransform {
 
 	constructor(transformData, containerName) {
 
-		const transformProps = this.traverseTransformProps(transformData)
-		this._AnchorPointTransform = this.getAnchorPointTransform(transformProps)
-		this._OuterTransform = this.getOuterPointTransform(transformProps)
+		this._TransformProps = this.traverseTransformProps(transformData)
+		this._AnchorPointTransform = this.getAnchorPointTransform(this._TransformProps)
+		this._OuterTransform = this.getOuterPointTransform(this._TransformProps)
 		this._ContainerName = containerName || 'Container'
 	}
 
@@ -120,6 +120,10 @@ export default class FlareTransform {
 			return anchorNode.convert()
 		}
 		
+	}
+
+	get opacity() {
+		return this._TransformProps && this._TransformProps.opacity
 	}
 
 }

--- a/converter/flare/models/properties/FlareTransform.js
+++ b/converter/flare/models/properties/FlareTransform.js
@@ -41,7 +41,7 @@ export default class FlareTransform {
 		}
 
 		if ('opacity' in transform) {
-			transformProperties.opacity = transform.opacity.getValueIfNotDefault(1);
+			transformProperties.opacity = transform.opacity.getValueIfNotDefault(-100);
 		}
 
 		return transformProperties

--- a/converter/flare/models/properties/FlareTransform.js
+++ b/converter/flare/models/properties/FlareTransform.js
@@ -41,7 +41,7 @@ export default class FlareTransform {
 		}
 
 		if ('opacity' in transform) {
-			transformProperties.opacity = transform.opacity.getValueIfNotDefault(-100);
+			transformProperties.opacity = transform.opacity.getValueIfNotDefault(100);
 		}
 
 		return transformProperties

--- a/converter/flare/models/shapes/FlareShapeFill.js
+++ b/converter/flare/models/shapes/FlareShapeFill.js
@@ -8,10 +8,13 @@ export default class FlareFill {
 	}
 
 	convert(id, animations, offsetTime, trimModifiers) {
-
+		if (!this._PaintData.opacity.animated && this._PaintData.opacity.value === 0) {
+			return void 0;
+		}
 		const node = new FlareNode('Color', null, 'colorFill');
 
 		const opacity = convertProperty(this._PaintData.opacity, 'opacity', animations, id, 0.01, offsetTime)
+		
 		node.opacity = opacity
 
 		const color = convertProperty(this._PaintData.color, 'color', animations, id, 1, offsetTime)

--- a/converter/flare/models/shapes/ShapeCollection.js
+++ b/converter/flare/models/shapes/ShapeCollection.js
@@ -118,6 +118,15 @@ export default class ShapeCollection {
 			let lastNode
 			transforms.forEach(transform => {
 				const flareTransform = new FlareTransform(transform)
+				if (flareTransform.opacity) {
+					const opacityNode = new FlareNode('Shape_Opacity', lastNode)
+					opacityNode.opacity = convertProperty(transform.opacity, 'opacity', animations, opacityNode.id, 0.01, offsetTime)
+					const opacityNodeData = opacityNode.convert()
+					if (!lastNode) {
+						mainNode = opacityNodeData
+					}
+					lastNode = opacityNodeData
+				}
 				const node = flareTransform.convert(animations, offsetTime)
 				if (node) {
 					if (!lastNode) {
@@ -128,12 +137,11 @@ export default class ShapeCollection {
 					lastNode = node
 				}
 			})
-			
+
 			if (lastNode) {
 				addChildToLastLeaves(lastNode, shape)
 			}
 		}
-
 
 		return mainNode
 	}

--- a/converter/flare/models/shapes/ShapeCollection.js
+++ b/converter/flare/models/shapes/ShapeCollection.js
@@ -60,6 +60,7 @@ export default class ShapeCollection {
 		return this._Paints.map(paint => {
 			return paint.convert(id, animations, offsetTime, trimModifierData, isHidden)
 		})
+		.filter(paint => !!paint)
 	}
 
 	exportTrim(animations, nodeId, offsetTime) {

--- a/converter/flare/models/shapes/ShapeCollection.js
+++ b/converter/flare/models/shapes/ShapeCollection.js
@@ -119,15 +119,19 @@ export default class ShapeCollection {
 			transforms.forEach(transform => {
 				const flareTransform = new FlareTransform(transform)
 				const node = flareTransform.convert(animations, offsetTime)
-				if (!lastNode) {
-					mainNode = node
-				} else {
-					addChildToLastLeaves(lastNode, node)
+				if (node) {
+					if (!lastNode) {
+						mainNode = node
+					} else {
+						addChildToLastLeaves(lastNode, node)
+					}
+					lastNode = node
 				}
-				lastNode = node
 			})
 			
-			addChildToLastLeaves(lastNode, shape)
+			if (lastNode) {
+				addChildToLastLeaves(lastNode, shape)
+			}
 		}
 
 

--- a/converter/flare/models/shapes/ShapeCollection.js
+++ b/converter/flare/models/shapes/ShapeCollection.js
@@ -55,10 +55,10 @@ export default class ShapeCollection {
 		this._IsClosed = true
 	}
 
-	convertTextures(animations, id, offsetTime, trimModifierData) {
+	convertTextures(animations, id, offsetTime, trimModifierData, isHidden) {
 
 		return this._Paints.map(paint => {
-			return paint.convert(id, animations, offsetTime, trimModifierData)
+			return paint.convert(id, animations, offsetTime, trimModifierData, isHidden)
 		})
 	}
 
@@ -91,14 +91,14 @@ export default class ShapeCollection {
 		return trimData
 	}
 
-	convert(animations, offsetTime) {
+	convert(animations, offsetTime, isHidden) {
 
 		const paths = this._Paths.map((pathData) => pathData.convert(animations, offsetTime))
 
 		let shapeNode = new FlareNode('Shape', [], 'shape')
 
 		const trimModifierData = this.exportTrim(animations, shapeNode.id, offsetTime)
-		const textures = this.convertTextures(animations, shapeNode.id, offsetTime, trimModifierData)
+		const textures = this.convertTextures(animations, shapeNode.id, offsetTime, trimModifierData, isHidden)
 
 		shapeNode.addChildren([...textures, ...paths])
 
@@ -107,6 +107,7 @@ export default class ShapeCollection {
 			blendMode: "srcOver",
 			drawOrder: this._DrawOrder,
 			transformAffectsStroke: true,
+			hidden: isHidden,
 		}
 
 		let mainNode = shape

--- a/converter/lottie/layers/layer.js
+++ b/converter/lottie/layers/layer.js
@@ -13,10 +13,12 @@ export default class Layer
 		this._StartPoint = null;
 		this._Id = null;
 		this._ParentId = null;
+		this._MaskType = null;
 		this._BlendMode = null;
 		this._Transform = null;
 		this._ParentHierarchy = [];
 		this._Masks = [];
+		this._IsTrackMask = false;
 	}
 
 	deserialize(json)
@@ -71,6 +73,17 @@ export default class Layer
 			this._Masks = value;
 		});
 
+		if (json['tt']) {
+			deserialize.number(json['tt'], (value) =>
+			{
+				this._MaskType = value;
+			});
+		}
+
+		if (json['td']) {
+			this._IsTrackMask = true;
+		}
+
 		return true;
 	}
 
@@ -108,6 +121,14 @@ export default class Layer
 
 	get masks() {
 		return this._Masks
+	}
+
+	get trackMaskType() {
+		return this._MaskType
+	}
+
+	get isTrackMask() {
+		return this._IsTrackMask
 	}
 
 }

--- a/converter/lottie/properties/animatable_property.js
+++ b/converter/lottie/properties/animatable_property.js
@@ -110,9 +110,16 @@ export default class AnimatableProperty
             return this;
         } else {
             const value = this.value;
-            if (value.length && value.findIndex(val => val !== defaultValue) === -1) {
-                return void 0;
+            if (Array.isArray(value)) {
+                if (value.length && value.findIndex(val => val !== defaultValue) === -1) {
+                    return void 0;
+                }
+            } else {
+                if(value === defaultValue) {
+                    return void 0;
+                }
             }
+            
             return this;
         }
     }


### PR DESCRIPTION
This PR:
- adds mask support 
- removes unnecessary intermediate nodes for opacity and transforms
- skips shape fills that have opacity set to 0