### PR TITLE
passing animation and offsetTime to inner shapes of a node

### DIFF
--- a/converter/flare/models/shapes/FlareShapeNode.js
+++ b/converter/flare/models/shapes/FlareShapeNode.js
@@ -40,7 +40,7 @@ export default class FlareShapeNode {
 	}
 
 	convert(animations, offsetTime) {
-		const children = this._Paths.map(path => path.convert())
+		const children = this._Paths.map(path => path.convert(animations, offsetTime))
 		let innerNode
 		if (children.length === 1) {
 			innerNode = children[0]


### PR DESCRIPTION
this PR fixes animated nested shapes of a FlareShapeNode that were animated and weren't getting the animations object.